### PR TITLE
melhoradas imagens no programa

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,1 @@
+Options -Indexes

--- a/data/schedule.yml
+++ b/data/schedule.yml
@@ -13,6 +13,7 @@
 #       - time: 'hh:mm' (as " ou ' são necessárias aqui)
 #         icon: (opcional) icon do fontawesome, exemplo: diamond. http://fortawesome.github.io/Font-Awesome/icons/
 #         image: (opcional) nome da imagem que pode substituir title e speaker
+#         imagelink: (opcional) link colocado na imagem
 #         title: título do evento (opcional se tiver image)
 #         speaker: (opcional)
 #           name: Nome do Speaker
@@ -104,9 +105,18 @@ days:
       - time: '16:30'
         icon: connectdevelop
         image: 'sponsors/primavera.png'
+        imagelink: 'http://pt.primaverabss.com/pt/'
       - time: '16:50'
         icon: connectdevelop
         image: 'sponsors/itgrow.png'
+        #text: >
+        #  Vivamus lectus quam, condimentum vitae tincidunt vel, congue id odio. Cum sociis
+        #  natoquesel usts et magnis dis parturient montes, nascetur ridiculust mus. Donec
+        #  vel neque ligula, sed cust metus. Vivamus porta velit at metus convallis porta.
+        #  Etiam eget nunc ante. Nullam sit amet act nisis egestr sapien. Aliquam nec aliquam
+        #  libero. Vestibulum consectetur sodales adipiscing. Vestibulum mi neque, vehicula
+        #  id hendrerit tincidunt, aliquam nec elitas quisque pellentesque varius urna.
+        #  Vivamus lectus quam, condimentum vitae tincidunt vel, congue id odio.
       - time: '17:10'
         icon: connectdevelop
         # image: 'sponsors/itgrow.png'

--- a/source/_schedule.html.slim
+++ b/source/_schedule.html.slim
@@ -36,8 +36,23 @@ section#schedule
                     .timeline-content
                       .event-content
                         div class="event-title#{' toggle-item-title' if event.text.present?}" data-count="1"
-                          - if event.image.present?
-                            =image_tag event.image, style: 'max-width:7.5em'
+                          - if event.image.present? and event.imagelink.present?
+                            a href=(event.imagelink)
+                              - if event.text.present?
+                                .hidden-phone
+                                  =image_tag event.image
+                                .visible-phone
+                                  =image_tag event.image, style: 'margin-top:30px'
+                              - else
+                                =image_tag event.image
+                          - elsif event.image.present?
+                            - if event.text.present?
+                              .hidden-phone
+                                =image_tag event.image
+                              .visible-phone
+                                =image_tag event.image, style: 'margin-top:30px'
+                            - else
+                              =image_tag event.image
                           h3= event.title
                           - if (speaker = event.speaker).present?
                             h4

--- a/source/css/app.css
+++ b/source/css/app.css
@@ -34,3 +34,8 @@
   opacity: 0;
   filter: alpha(opacity=0);
 }
+
+.event-title img {
+  margin-top: 0.5em;
+  max-width:7.5em;
+}


### PR DESCRIPTION
- adicionado link para a Primavera
- imagens (quase) centradas verticalmente
- caso haja uma descrição, a imagem é empurrada para baixo na vista de telemovel para dar espaço ao botão [+]
- na vista de telemóvel, com a imagem chegada para baixo, consegue-se clicar no [+] para abrir a descrição ou no logotipo para ir para o site da empresa

extra:
- bloqueada listagem de ficheiros nas pastas que não têm index.html (images, css, etc) quado se usa um servidor que suporte .htaccess
